### PR TITLE
CI: Enable automatic NPM deployment for tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,3 +22,12 @@ install:
   - npm install --no-optional
 
 script: npm test
+
+deploy:
+  provider: npm
+  email: stefan.penner+ember-cli@gmail.com
+  api_key:
+    secure: omA2oAPkDu8yI/jm+quACiBSRk+EdnqOz47Aa+tEnDjQkGHaY59L3vW/xKcp+e0+RZgHzC3sLPP+c6/7ahXTRvomD6haNpZGnF4QlK3TBtyWyg5g7efRSS55HW/eB7GBl+1VvGP0yYmu+i3mOzwP4gmY4uvQfttrgKhSsunv7DqyKJ1KdFDjs2kEE32WwvOYDw1Hsep9Av0OmpwkZeHgxJaFCXu7VAB092FOZQMDkmatACvqPBFUPB1FKz/LwllxZv3NQlsHgCx/4AU8npV9LJAQQJzUa/a+4wIsit6mxToxhLmilbr0JfldtBrjjqBA/CVFmtYH4PIzqOpZp9JLbvUz0+3AtJbwf7FBSwwDZ6rikY7ivKYbHlbbhdJPMXpMRpkTLGZaq+EzgItHhp9bahR8Tno3rLGJtQgd2/fCHN5MLODzNAg+jcHqnFtfqZSe4iX82Lkn6yyCWcAYwGdT0XB10Hg/Lbu6NLYM1erAJfVisASb2uIeOL/QfvNMhVrB2IgAJs0kL36M64aQ2AzBZ8+8Jiyy4xFtQLUdmQXveNVq5vBBax8tM8aD/POoLAdzZJno9bRIpgr8e95qR4d3DBy43smrzZnkFVJjBaGNDYuUNtIQEKXIUmZhmDujbEDj2E1SfSPpEs5QtD0U0mZgK1aE6X63gnM+jObzD0SS7iM=
+  on:
+    tags: true
+    repo: ember-cli/ember-cli-lodash-subset


### PR DESCRIPTION
After merging this you no longer have to `npm publish` manually. TravisCI will test all pushed tags and deploy automatically after all tests passed.

/cc @nathanhammond @stefanpenner @rwjblue